### PR TITLE
MODIFY | Addon | Rancher | change LB to NP

### DIFF
--- a/addons/rancher/master.yaml
+++ b/addons/rancher/master.yaml
@@ -62,7 +62,7 @@ spec:
       name: https
     selector:
       app: cattle
-    type: LoadBalancer
+    type: NodePort
 
 ---
 


### PR DESCRIPTION
this commit change the default Loadbalancer to a default NodePort

Signed-off-by: Manuel Müller <mueller.m.h@gmail.com>