### PR TITLE
Tweaking addon addition/removal functionality

### DIFF
--- a/cmd/cli/addon.go
+++ b/cmd/cli/addon.go
@@ -25,6 +25,7 @@ import (
 )
 
 var Addon addon.Addon
+var scope string
 
 // addonCmd represents the addon command
 var addonCmd = &cobra.Command{
@@ -51,7 +52,9 @@ var addonInstallCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
-		Addon.Install(args[0])
+		fmt.Println("Args are --- ", args)
+		fmt.Println("Scope --- ", scope)
+		Addon.Install(args[0], scope)
 	},
 }
 
@@ -66,7 +69,7 @@ var addonDestroyCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
-		Addon.Destroy(args[0])
+		Addon.Destroy(args[0], scope)
 	},
 }
 
@@ -144,4 +147,7 @@ func init() {
 	addonCmd.AddCommand(addonDestroyCmd)
 
 	addonCmd.PersistentFlags().StringVar(&addon.KubeConfig, "kubeconfig", "", "kubeconfig path")
+	addonInstallCmd.Flags().StringVarP(&scope, "scope", "s", "", "Namespace scope in which the addon is installed")
+	addonDestroyCmd.Flags().StringVarP(&scope, "scope", "s", "", "Namespace scope in which the installed addon is to be destroyed")
+
 }

--- a/cmd/cli/addon.go
+++ b/cmd/cli/addon.go
@@ -52,8 +52,6 @@ var addonInstallCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
-		fmt.Println("Args are --- ", args)
-		fmt.Println("Scope --- ", scope)
 		Addon.Install(args[0], scope)
 	},
 }

--- a/internal/addon/main.go
+++ b/internal/addon/main.go
@@ -28,7 +28,11 @@ func (a *Addon) Destroy(addonNameOrGitPath, scope string) (error, string) {
 		return err, addonName
 	}
 	if os.IsNotExist(err) {
-		executeMainSh(addonName, scope)
+		err = executeMainSh(addonName, scope)
+		if err != nil {
+			fmt.Println("Error in executing main.sh , aborting addon removal.")
+			return err, addonName
+		}
 	}
 	deleteMainYml(addonName)
 	fmt.Println(strings.Replace(addonName, "tk8-addon-", "", 1), "destroy complete")

--- a/internal/addon/main.go
+++ b/internal/addon/main.go
@@ -19,13 +19,19 @@ func (a *Addon) Create(addonName string) (error, string) {
 	return nil, addonName
 }
 
-func (a *Addon) Destroy(addonNameOrGitPath string) (error, string) {
+func (a *Addon) Destroy(addonNameOrGitPath, scope string) (error, string) {
 	_, addonName := a.Get(addonNameOrGitPath)
 	fmt.Println("Destroying", strings.Replace(addonName, "tk8-addon-", "", 1))
-	executeMainSh(addonName)
+	err := executeDestroySh(addonName, scope)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Println("Error in executing destroy.sh , aborting addon removal.")
+		return err, addonName
+	}
+	if os.IsNotExist(err) {
+		executeMainSh(addonName, scope)
+	}
 	deleteMainYml(addonName)
 	fmt.Println(strings.Replace(addonName, "tk8-addon-", "", 1), "destroy complete")
-
 	return nil, addonName
 }
 
@@ -58,17 +64,20 @@ func (a *Addon) Get(addonNameOrGitPath string) (error, string) {
 
 }
 
-func (a *Addon) Install(addonNameOrGitPath string) {
+func (a *Addon) Install(addonNameOrGitPath string, scope string) {
 	_, addonName := a.Get(addonNameOrGitPath)
 	fmt.Println("Install", addonName)
-	executeMainSh(addonName)
-	err := applyMainYml(addonName)
+	err := executeMainSh(addonName, scope)
+	if err != nil {
+		fmt.Println("Error in executing main.sh , aborting addon installation.")
+		return
+	}
+	err = applyMainYml(addonName)
 	if err == nil {
 		fmt.Println(addonName, "installation complete")
 	} else {
 		fmt.Println(err)
 	}
-
 }
 
 // KubeConfig provide the path to the local kube config
@@ -97,15 +106,34 @@ func applyMainYml(addonName string) error {
 	return err
 }
 
-func executeMainSh(addonName string) {
+func executeMainSh(addonName, scope string) error {
 	if _, err := os.Stat("./addons/" + addonName + "/main.sh"); err == nil {
 		fmt.Println("execute main.sh")
-		cEx := exec.Command("/bin/sh", "./main.sh")
+		cEx := exec.Command("/bin/sh", "./main.sh", scope)
 		cEx.Dir = "./addons/" + addonName
 		printTerminalLog(cEx)
-		cEx.Wait()
-		return
+		err = cEx.Wait()
+		if err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func executeDestroySh(addonName, scope string) error {
+	_, err := os.Stat("./addons/" + addonName + "/destroy.sh")
+	if err != nil {
+		return err
+	}
+	fmt.Println("execute destroy.sh")
+	cEx := exec.Command("/bin/sh", "./destroy.sh", scope)
+	cEx.Dir = "./addons/" + addonName
+	printTerminalLog(cEx)
+	err = cEx.Wait()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func printTerminalLog(cEx *exec.Cmd) {
@@ -146,9 +174,9 @@ func cloneExample(addonName string) {
 func deleteMainYml(addonName string) {
 
 	var cEx *exec.Cmd
-	fileName := addonName + ".yml"
+	fileName := "main.yml"
 	if _, err := os.Stat("./addons/" + addonName + "/" + fileName); err != nil {
-		fileName = addonName + ".yaml"
+		fileName = "main.yaml"
 	}
 	if _, err := os.Stat("./addons/" + addonName + "/" + fileName); err == nil {
 		fmt.Println("delete", strings.Replace(addonName, "tk8-addon-", "", 1), "from cluster")


### PR DESCRIPTION
Adding functionality for addons where different main.sh is required for removal and installation.

Added a new file - destroy.sh
If an addon subfolder has this file, then this to be executed else execute main.sh for addon removal.

example: helm where installation and removal of tiller component happens with the help of helm init and helm reset and not yaml files

also fixed a bug which wasnt destroying the installed addons from the cluster
Signed-off-by: Imran Pochi <pochiimran@yahoo.co.in>