### PR TITLE
Features to specify monitoring,instance_type,ami

### DIFF
--- a/config-cattle-aws-existing-vpc.yaml
+++ b/config-cattle-aws-existing-vpc.yaml
@@ -1,6 +1,7 @@
 cattle-aws:
-   request_spot_instances: # boolean value - set it as true/fase/empty
+   request_spot_instances: false
    spot_price: # spot instance pricing. Ex. "0.75"
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name: "rancher-controlplane-role"
    iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
@@ -14,10 +15,10 @@ cattle-aws:
    vpc_id: "vpc-1abcdgggga72a691a"
    subnet_id: "subnet-1f98d368767ge1e71"
    security_group_name: "rancher-nodes"
-   os: "ubuntu"
-   instance_type: "t2.medium"
-   aws_secret_access_key:
-   aws_default_region: "eu-central-1"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "true"
    overlap_node_pool:
       hostname_prefix: "cattle-aws-cluster"

--- a/config-cattle-aws-novpc-nooverlap.yaml
+++ b/config-cattle-aws-novpc-nooverlap.yaml
@@ -1,8 +1,10 @@
 cattle-aws:
-   request_spot_instances: # boolean value - set it as true/fase/empty
+   request_spot_instances: false
    spot_price: # spot instance pricing. Ex. "0.75" 
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name:
+   iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
    rancher_cluster_name: "cattle-aws-cluster"
    rancher_api_url: "https://rancher.xyz.com/v3"
    rancher_access_key:
@@ -13,10 +15,10 @@ cattle-aws:
    vpc_id:
    subnet_id:
    security_group_name:
-   os: "ubuntu"
-   instance_type: "t2.medium"
-   aws_secret_access_key:
-   aws_default_region: "eu-central-1"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "false"
    overlap_node_pool:
       hostname_prefix:

--- a/config-cattle-aws-novpc-overlap.yaml
+++ b/config-cattle-aws-novpc-overlap.yaml
@@ -1,8 +1,10 @@
 cattle-aws:
-   request_spot_instances: # boolean value - set it as true/fase/empty
+   request_spot_instances: false
    spot_price:  # spot instance pricing. Ex. "0.75"
+   cloudwatch_monitoring: false
    root_disk_size: 20
    iam_instance_profile_name:
+   iam_instance_profile_worker: # specify if overlap_cp_etcd_worker is false and existing_vpc is true
    rancher_cluster_name: "cattle-aws-cluster"
    rancher_api_url: "https://rancher.xyz.com/v3"
    rancher_access_key:
@@ -13,10 +15,10 @@ cattle-aws:
    vpc_id:
    subnet_id:
    security_group_name:
-   os: "ubuntu"
-   instance_type: "t2.medium"
-   aws_secret_access_key:
-   aws_default_region: "eu-central-1"
+   ami_id: "test123" # specify if you know the specific AMI ID. If used, keep below os field empty (not that setting it would impact).
+   os: "" # specify the OS. Supported values: ubuntu, centos, coreos. Keep above field empty if this is being used.  
+   controlplane_instance_type: "t2.medium"
+   worker_instance_type: "t2.large"
    overlap_cp_etcd_worker: "true"
    overlap_node_pool:
       hostname_prefix: "cattle-aws-cluster"

--- a/pkg/templates/variables.go
+++ b/pkg/templates/variables.go
@@ -233,6 +233,24 @@ variable "default_tags" {
 }
 `
 var VariablesCattleAWS = `
+variable "cloudwatch_monitoring" {
+  default     = "{{.CloudwatchMonitoring}}"
+  description = "Enable/Disable cloudwatch monitoring"
+  type        = "string"
+}
+
+variable "ami_id" {
+  default     = "{{.AmiID}}"
+  description = "AMI ID for instances"
+  type        = "string"
+}
+
+variable "controlplane_instance_type" {
+  default     = "{{.ControlPlaneInstanceType}}"
+  description = "Control plane instance type"
+  type        = "string"
+}
+
 variable "request_spot_instances" {
   default     = "{{.RequestSpotInstances}}"
   description = "Request spot instances for the node template"
@@ -325,8 +343,8 @@ variable "os" {
   type        = "string"
 }
 
-variable "instance_type" {
-  default     = "{{.InstanceType}}"
+variable "worker_instance_type" {
+  default     = "{{.WorkerInstanceType}}"
   description = "Instance type"
   type        = "string"
 }


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

This PR is required to resolve the following issues of cattle-aws provisioner:
* https://github.com/kubernauts/tk8-provisioner-cattle-aws/issues/2
* https://github.com/kubernauts/tk8-provisioner-cattle-aws/issues/3
* https://github.com/kubernauts/tk8-provisioner-cattle-aws/issues/4

It adds necessary changes to TK8 in order to support the new features:
1. Cloudwatch monitoring
2. Separate instance types for controlplane and worker nodes
3. Provision to specify AMI ID