### PR TITLE
Add interactive option for cluster install

### DIFF
--- a/pkg/common/main.go
+++ b/pkg/common/main.go
@@ -3,6 +3,8 @@ package common
 import (
 	"bufio"
 	"fmt"
+	"github.com/manifoldco/promptui"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -196,4 +198,18 @@ func CopyDir(src string, dst string) (err error) {
 	}
 
 	return
+}
+
+
+func ProvisionerList() string{
+	prompt := promptui.Select{
+		Label: "Select the Tk8 provisioner",
+		Items: []string{"aws", "cattle-aws", "eks", "rke"},
+	}
+	_, result, err := prompt.Run()
+	if err != nil {
+		log.Fatalf("Prompt failed %v\n", err)
+	}
+	fmt.Printf("You chose %q\n", result)
+	return result
 }

--- a/pkg/provisioner/main.go
+++ b/pkg/provisioner/main.go
@@ -11,6 +11,7 @@ import (
 )
 
 var IOnly bool = false
+var Interactive bool
 
 type Provisioner interface {
 	Init(args []string)


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

This PR adds the feature of an interactive prompt where the user can select which provisioner they want to use for creating the cluster. Fixes: #110 