### PR TITLE
New Provisioner for AWS based on kubeadm

### DIFF
--- a/cmd/cli/provisioner.go
+++ b/cmd/cli/provisioner.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	aws "github.com/kubernauts/tk8-provisioner-aws"
+	kubeadmaws "github.com/kubernauts/tk8-provisioner-aws-kubeadm"
 	azure "github.com/kubernauts/tk8-provisioner-azure"
 	baremetal "github.com/kubernauts/tk8-provisioner-baremetal"
 	cattleaws "github.com/kubernauts/tk8-provisioner-cattle-aws"
@@ -37,15 +38,16 @@ import (
 
 var name string
 var provisioners = map[string]provisioner.Provisioner{
-	"aws":        aws.NewAWS(),
-	"azure":      azure.NewAzure(),
-	"baremetal":  baremetal.NewBaremetal(),
-	"cattle-aws": cattleaws.NewCattleAWS(),
-	"cattle-eks": cattleeks.NewCattleEKS(),
-	"eks":        eks.NewEKS(),
-	"nutanix":    nutanix.NewNutanix(),
-	"openstack":  openstack.NewOpenstack(),
-	"rke":        rke.NewRKE(),
+	"aws":         aws.NewAWS(),
+	"azure":       azure.NewAzure(),
+	"baremetal":   baremetal.NewBaremetal(),
+	"cattle-aws":  cattleaws.NewCattleAWS(),
+	"cattle-eks":  cattleeks.NewCattleEKS(),
+	"eks":         eks.NewEKS(),
+	"nutanix":     nutanix.NewNutanix(),
+	"openstack":   openstack.NewOpenstack(),
+	"rke":         rke.NewRKE(),
+	"aws-kubeadm": kubeadmaws.NewAWSKubeadm(),
 }
 
 var provisionerInstallCmd = &cobra.Command{

--- a/pkg/templates/variables.go
+++ b/pkg/templates/variables.go
@@ -528,3 +528,90 @@ variable "AWS_DEFAULT_REGION" {
   description = "AWS default region"
 }
 `
+var VariablesKubeadmAWS = `
+variable "aws_region" {
+  description = "Region where Cloud Formation is created"
+  default     = "{{.AWSRegion}}"
+}
+
+variable "cluster_name" {
+  description = "Name of the AWS Kubernetes cluster - will be used to name all created resources"
+  default = "{{.ClusterName}}"
+}
+
+variable "tags" {
+  description = "Tags used for the AWS resources created by this template"
+  type        = map(string)
+  default = {{.TagsInStringForm}}
+}
+
+variable "tags2" {
+  description = "Tags in format used for the AWS Autoscaling Group"
+  type        = list(object({ key = string, value = string, propagate_at_launch = bool }))
+  default = {{.Tags2InStringForm}}
+}
+
+variable "addons" {
+  description = "list of YAML files with Kubernetes addons which should be installed"
+  type        = list(string)
+  default = {{.AddonsInStringForm}}
+}
+
+variable "master_instance_type" {
+  description = "Type of instance for master"
+  default = "{{.MasterInstanceType}}"
+}
+
+variable "worker_instance_type" {
+  description = "Type of instance for workers"
+  default = "{{.WorkerInstanceType}}"
+}
+
+variable "master_subnet_id" {
+  description = "The subnet-id to be used for the master instance"
+  default = "{{.MasterSubnetID}}"
+}
+
+variable "worker_subnet_ids" {
+  description = "The subnet-ids to be used for the worker instances"
+  type        = list(string)
+  default = {{.WorkerSubnetIDSInStringForm}}
+}
+
+variable "min_worker_count" {
+  description = "Minimal number of worker nodes"
+  default = "{{.MinWorkerCount}}"
+}
+
+variable "max_worker_count" {
+  description = "Maximal number of worker nodes"
+  default = "{{.MaxWorkerCount}}"
+}
+
+variable "ssh_public_key" {
+  description = "Path to the pulic part of SSH key which should be used for the instance"
+  default     = "{{.SSHPublicKey}}"
+}
+
+variable "hosted_zone" {
+  description = "Hosted zone to be used for the alias"
+  default = "{{.HostedZone}}"
+}
+
+variable "hosted_zone_private" {
+  description = "Is the hosted zone public or private"
+  default     = "{{.HostedZonePrivate}}"
+}
+
+variable "ssh_access_cidr" {
+  description = "List of CIDRs from which SSH access is allowed"
+  type        = list(string)
+  default = {{.SSHAccessCIDRInStringForm}}
+}
+
+variable "api_access_cidr" {
+  description = "List of CIDRs from which API access is allowed"
+  type        = list(string)
+  default = {{.APIAccessCIDRInStringForm}}
+}
+`


### PR DESCRIPTION
This provisioner takes the implementation of https://github.com/scholzj/aws-kubernetes
and integrates as a provisioner for tk8.

Provisioner implementation can be found here at https://github.com/kubernauts/tk8-provisioner-aws-kubeadm